### PR TITLE
Add configurable routes support for flexible deployments

### DIFF
--- a/config/mixpost.php
+++ b/config/mixpost.php
@@ -17,6 +17,22 @@ return [
     'redirect_unauthorized_users_to_route' => 'login',
 
     /*
+     * Route configuration for Mixpost.
+     * You can customize the routing behavior by modifying these values.
+     * Set any value to null to exclude it from the route group configuration.
+     */
+    'routes' => [
+        'middleware' => [
+            'web',
+            \Inovector\Mixpost\Http\Middleware\Auth::class,
+            \Inovector\Mixpost\Http\Middleware\HandleInertiaRequests::class
+        ],
+        'prefix' => env('MIXPOST_ROUTE_PREFIX', 'mixpost'),
+        'name' => 'mixpost.',
+        'domain' => env('MIXPOST_ROUTE_DOMAIN', null),
+    ],
+
+    /*
      * The disk on which to store added files.
      * Choose one or more of the disks you've configured in config/filesystems.php.
      */

--- a/config/mixpost.php
+++ b/config/mixpost.php
@@ -28,7 +28,7 @@ return [
             \Inovector\Mixpost\Http\Middleware\HandleInertiaRequests::class
         ],
         'prefix' => env('MIXPOST_ROUTE_PREFIX', 'mixpost'),
-        'name' => 'mixpost.',
+        'as' => 'mixpost.',
         'domain' => env('MIXPOST_ROUTE_DOMAIN', null),
     ],
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,13 +33,23 @@ use Inovector\Mixpost\Http\Controllers\TagsController;
 use Inovector\Mixpost\Http\Middleware\Auth as MixpostAuthMiddleware;
 use Inovector\Mixpost\Http\Middleware\HandleInertiaRequests;
 
-Route::middleware([
-    'web',
-    MixpostAuthMiddleware::class,
-    HandleInertiaRequests::class
-])->prefix('mixpost')
-    ->name('mixpost.')
-    ->group(function () {
+// Get route configuration from config file
+$routeConfig = config('mixpost.routes', [
+    'middleware' => [
+        'web',
+        MixpostAuthMiddleware::class,
+        HandleInertiaRequests::class
+    ],
+    'prefix' => 'mixpost',
+    'name' => 'mixpost.'
+]);
+
+// Filter out null and empty values to avoid unintended behavior
+$routeConfig = array_filter($routeConfig, function ($value) {
+    return !is_null($value) && $value !== '';
+});
+
+Route::group($routeConfig, function () {
         Route::get('/', DashboardController::class)->name('dashboard');
         Route::get('reports', ReportsController::class)->name('reports');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,13 +41,8 @@ $routeConfig = config('mixpost.routes', [
         HandleInertiaRequests::class
     ],
     'prefix' => 'mixpost',
-    'name' => 'mixpost.'
+    'as' => 'mixpost.'
 ]);
-
-// Filter out null and empty values to avoid unintended behavior
-$routeConfig = array_filter($routeConfig, function ($value) {
-    return !is_null($value) && $value !== '';
-});
 
 Route::group($routeConfig, function () {
         Route::get('/', DashboardController::class)->name('dashboard');


### PR DESCRIPTION
## Summary
This PR adds support for configurable routes, allowing Mixpost to be deployed with custom routing configurations such as subdomain routing or custom prefixes.

## Why this change?
Currently, Mixpost has hardcoded route configuration which makes it difficult to:
- Deploy on subdomains without a path prefix
- Integrate into existing applications with custom routing needs  
- Whitelabel the application

## What changed?
- Routes configuration now reads from `config('mixpost.routes')` instead of hardcoded values
- Changed route group parameter from `'name'` to `'as'` for proper Laravel route name prefix handling
- Updated default config to use `'as'` instead of `'name'`

## Usage
Users can now configure routes in their `config/mixpost.php`:

```php
'routes' => [
    'middleware' => ['web', 'auth'],
    'prefix' => '',  // Empty for subdomain routing
    'as' => 'mixpost.',
    'domain' => 'admin.example.com',
],
```

This enables deployment scenarios like:
- `admin.example.com/` (subdomain without prefix)
- `example.com/social/` (custom prefix)
- Default: `example.com/mixpost/` (unchanged)

## Testing
- Tested with subdomain routing on local environment
- Routes properly registered with correct names
- Backward compatible with existing installations

## Breaking changes
None. The default configuration remains unchanged.